### PR TITLE
FreeBSD uses "amd64"

### DIFF
--- a/configure
+++ b/configure
@@ -38,7 +38,7 @@ case "$cpu" in
 i386 | i486 | i586 | i686 | i86pc | BePC)
     cpu="x86"
     ;;
-x86_64)
+x86_64 | amd64)
     cpu="x86-64"
     ;;
 armv4l)


### PR DESCRIPTION
FreeBSD, and possibly other OSes, use "amd64" instead of "x86-64" to denote 64-bit x86 systems.