### PR TITLE
Use system's default C compiler if available

### DIFF
--- a/configure
+++ b/configure
@@ -29,8 +29,15 @@ includedir=""
 mandir=""
 sysroot=""
 cross_prefix=""
-cc="gcc"
-host_cc="gcc"
+
+cc=$(which cc)
+if [ "$cc" = "" ]; then
+    cc="gcc"
+    host_cc="gcc"
+else
+    host_cc="$cc"
+fi
+
 ar="ar"
 strip="strip"
 cpu=$(uname -m)


### PR DESCRIPTION
In the case of FreeBSD, the OS comes packaged with LLVM and has the binary "cc" available by default.

This also means we can use LLVM in general instead of GCC!

So, let's test to see if "cc" is available, and if not, default back to "gcc"