### PR TITLE
fix: fix for Apple M3 Max - arm64

### DIFF
--- a/configure
+++ b/configure
@@ -51,7 +51,7 @@ x86_64 | amd64)
 armv4l)
     cpu="armv4l"
     ;;
-aarch64)
+aarch64 | arm64)
     cpu="arm64"
     ;;
 alpha)


### PR DESCRIPTION
# Description
This is a fix for Apple M3 Max (arm64).

The PVSnesLib builds as expected on Apple M3 Max.