### PR TITLE
Prefix filename to static symbols to avoid conflicts

### DIFF
--- a/816-gen.c
+++ b/816-gen.c
@@ -160,7 +160,7 @@ char *get_sym_str(Sym *sym)
             && !((sym->type.t & VT_BTYPE) == VT_FUNC))
             sprintf(name, "%s_FUNC_%s_", STATIC_PREFIX, current_fn);
         else
-            strcpy(name, STATIC_PREFIX);
+            sprintf(name, "%s%s_", STATIC_PREFIX, unique_token);
     }
 
     /* add symbol name */

--- a/libtcc.c
+++ b/libtcc.c
@@ -786,7 +786,7 @@ static void put_extern_sym2(
             if ((sym->type.t & VT_STATICLOCAL) && current_fn[0] != 0)
                 sprintf(buf1, "%s_FUNC_%s_", STATIC_PREFIX, current_fn);
             else
-                strcpy(buf1, STATIC_PREFIX);
+                sprintf(buf1, "%s%s_", STATIC_PREFIX, unique_token);
             strcat(buf1, name);
             name = buf1;
         }


### PR DESCRIPTION
When global static variables with the same name are defined in separate files, symbol conflicts occur.
This pull request changes the symbols of global static variables to include the filename to fix this issue.