### PR TITLE
HiROM-FastROM_implementation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ The produced code is:
 ### Some considerations
 
 TCC is a ANSI C compiler, mostly implemented in C90. **Do not use any non-C90 features** that are not already in use.
-  
+
 For more informations, see [CodingStyle](CodingStyle)
 
 ## Getting Started
@@ -58,11 +58,13 @@ See the help option.
 ```bash
 ./816-tcc -h
 
-usage: 816-tcc [-v] [-c] [-o outfile] [-Idir] [-Wwarn] [infile1 infile2...]
+usage: 816-tcc [-v] [-c] [-H] [-F] [-o outfile] [-Idir] [-Wwarn] [infile1 infile2...]
 
 General options:
   -v          display current version, increase verbosity
   -c          compile only - generate an object file
+  -H          hiRom (Mode 21) Memory Map compilation
+  -F          FastRom compilation
   -o outfile  set output filename
   -Wwarning   set or reset (with 'no-' prefix) 'warning' (see man page)
   -w          disable all warnings

--- a/tcc.h
+++ b/tcc.h
@@ -488,6 +488,11 @@ struct TCCState
     int verbose;
     /* compile with debug symbol (and use them if error during execution) */
     int do_debug;
+
+    /* if true, compile Mode 21 (HiRom) Memory mapped libraries, Mode 20 (LoRom) by default */
+    int hirom_comp;
+    /* if true, compile FastRom libraries */
+    int fastrom_comp;
 #ifdef CONFIG_TCC_BCHECK
     /* compile with built-in memory and bounds checker */
     int do_bounds_check;


### PR DESCRIPTION
As the readme file sugest, two new uses have been added:

  -H         hiRom (Mode 21) Memory Map compilation
  -F          FastRom compilation
  
  This changes are necessary to make PVSNESLIB work propperly with new .obj compilations